### PR TITLE
Added MPD parsing for Rhombus VOD URIs. This should allow for better WAN support

### DIFF
--- a/CopyFootageToLocalStorage/README.md
+++ b/CopyFootageToLocalStorage/README.md
@@ -21,21 +21,21 @@ NOTE: If you have already generated the Typescript client and have a RhombusType
 4. Run `npm install` in the CopyFootageToLocalStorage directory
 5. Create a `.env` file in the CopyFootageToLocalStorage source directory using the following structure (without the angle brackets)
 
-    API_KEY=<YOUR API KEY>
+    API_KEY=`<YOUR API KEY>`
 
-    CAMERA_UUID=<YOUR CAMERA UUID>
+    CAMERA_UUID=`<YOUR CAMERA UUID>`
 
-    OUTPUT=<OUTPUT mp4 PATH>
+    OUTPUT=`<OUTPUT mp4 PATH>`
 
     # Other optional parameters
     
-    START_TIME=<START TIME IN SECONDS SINCE EPOCH>
+    START_TIME=`<START TIME IN SECONDS SINCE EPOCH>`
 
-    DURATION=<DURATION IN SECONDS>
+    DURATION=`<DURATION IN SECONDS>`
 
-    DEBUG=<TRUE or FALSE>
+    DEBUG=`<TRUE or FALSE>`
 
-    CONNECTION_TYPE=<WAN OR LAN> 
+    CONNECTION_TYPE=`<WAN OR LAN>`
 
 
 NOTE: CONNECTION_TYPE parameter is optional, but it will specify whether to use a WAN or LAN connection from the camera to download the VODs. It is by default LAN and unless the NodeJS server is running on a separate wifi from the camera, which would be very unlikely...

--- a/CopyFootageToLocalStorage/index.ts
+++ b/CopyFootageToLocalStorage/index.ts
@@ -23,9 +23,11 @@
 import { Configuration, CameraWebserviceApi, OrgWebserviceApi } from "@rhombus/API"
 import * as path from "path"
 import * as fs from "fs"
+import { XMLParser } from "fast-xml-parser";
+
 /*
   *
-  * @import Import axios to download the vod
+  * @import Import axios to download the vod.
   * */
 const axios = require('axios').default;
 
@@ -115,6 +117,68 @@ const getConnectionType = (): ConnectionType => {
 		return ConnectionType.WAN;
 	}
 	return ConnectionType.LAN;
+}
+
+/*
+  * 
+  * @export
+  * @interface RhombusMPDInfo
+  *
+  * */
+export interface RhombusMPDInfo {
+	/*
+	  * @type {string} The pattern containing "$Number$" which can be replaced with an index that is incremented for each segment.
+	  * @memberof RhombusMPDInfo
+	  * */
+	segPattern: string;
+
+	/*
+	  * @type {string} The string which is appended to the end of the mpd URI to get the start mp4 file.
+	  * @memberof RhombusMPDInfo
+	  * */
+	segInitStr: string;
+
+	/*
+	  * @type {number} The starting index which will be incremented for each segment.
+	  * @memberof RhombusMPDInfo
+	  * */
+	startIndex: number;
+}
+
+/*
+  *
+  * @export 
+  * @method Parse relevant information from a raw MPD XML string.
+  *
+  * @param {string} [mpdDocRaw] the raw XML string that is retrieved from downloading the mpd document from a Rhombus URI.
+  * @return {RhombusMPDInfo} the info relevant to downloading from MPD stream.
+  * */
+export const parseRhombusMPD = (mpdDocRaw: string): RhombusMPDInfo => {
+	const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" });
+	const mpdDoc = parser.parse(mpdDocRaw);
+
+	const segmentTemplate = mpdDoc.MPD.Period.AdaptationSet.SegmentTemplate;
+
+	return {
+		segPattern: segmentTemplate.media,
+		segInitStr: segmentTemplate.initialization,
+		startIndex: parseInt(segmentTemplate.startNumber),
+	};
+}
+
+/*
+  *
+  * @export 
+  * @method Save an m4v or mp4 url to the specified output file
+  *
+  * @param {number} [index] the segment index starting at 0.
+  * @param {string} [mpdUri] the MPD URI with the correct start and end times. This should have a file.mpd or clip.mpd ending.
+  * @param {RhombusMPDInfo} [rhombusInfo] the MPD info parsed using `parseRhombusMPD(string)`.
+  * @param {string} [mpdName] either "file.mpd" or "clip.mpd", depending on if you are using WAN or LAN.
+  * */
+export const getSegmentURI = (index: number, mpdUri: string, rhombusInfo: RhombusMPDInfo, mpdName: string): string => {
+	const replacement = rhombusInfo.segPattern.replace("$Number$", (index + rhombusInfo.startIndex).toString());
+	return mpdUri.replace(mpdName, replacement);
 }
 
 /*
@@ -228,12 +292,21 @@ const main = async (apiKey: string | undefined, outputPath: string | undefined, 
 
 		debugLog("Camera media uri response: " + JSON.stringify(mediaRes, null, 2));
 
-		if (mediaRes.lanVodMpdUrisTemplates == undefined) {
-			errorLog("Failed to get media URIs");
-			return;
-		}
+		if (connectionType == ConnectionType.LAN) {
+			if (mediaRes.lanVodMpdUrisTemplates == undefined) {
+				errorLog("Failed to get media URIs");
+				return;
+			}
 
-		mpdUriTemplate = mediaRes.lanVodMpdUrisTemplates[0];
+			mpdUriTemplate = mediaRes.lanVodMpdUrisTemplates[0];
+		} else {
+			if (mediaRes.wanVodMpdUriTemplate == undefined) {
+				errorLog("Failed to get media URIs");
+				return;
+			}
+
+			mpdUriTemplate = mediaRes.wanVodMpdUriTemplate;
+		}
 
 		debugLog("Raw mpd uri template: " + mpdUriTemplate);
 	} catch (e) {
@@ -243,7 +316,7 @@ const main = async (apiKey: string | undefined, outputPath: string | undefined, 
 
 
 	// We need to replace {START_TIME} and {DURATION} with the correct values in order to properly download the file
-	let mpdUri = mpdUriTemplate.replace("{START_TIME}", startTime.toString()).replace("{DURATION}", duration.toString());
+	let mpdUri: string = mpdUriTemplate.replace("{START_TIME}", startTime.toString()).replace("{DURATION}", duration.toString());
 
 	debugLog("Mpd uri: " + mpdUri);
 
@@ -259,10 +332,14 @@ const main = async (apiKey: string | undefined, outputPath: string | undefined, 
 	// The federated token is set as a cookie. Without this we would be unable to download the files from Rhombus
 	axios.defaults.headers.common['Cookie'] = 'RSESSIONID=RFT:' + federatedSessionToken;
 
-	// Because our URI is an mpd, we need to get each of the segments. The seg_init.mp4 is the first of these. 
-	// Just replace clip.mpd at the end of the URL with seg_init.mp4 
-	// This also needs to be written since this is the first of our segments
-	const initSegUri = mpdUri.replace(mpdName, "seg_init.mp4");
+	// Get the Rhombus MPD Doc info.
+	const mpdDocRaw = await axios.get(mpdUri, { responseType: 'json' });
+	const rhombusMPDInfo = parseRhombusMPD(mpdDocRaw.data);
+
+	// Because our URI is an mpd, we need to get each of the segments. The rhombusMPDInfo.segInitStr initializes the MP4 file. 
+	// Just replace clip.mpd at the end of the URL with the segInitStr.
+	// This also needs to be written since this is the first of our segments.
+	const initSegUri = mpdUri.replace(mpdName, rhombusMPDInfo.segInitStr);
 	debugLog("Init segment uri: " + initSegUri);
 	await saveClip(outputPath, initSegUri, true);
 
@@ -270,7 +347,7 @@ const main = async (apiKey: string | undefined, outputPath: string | undefined, 
 	for (let i = 0; i < duration / 2; i++) {
 		// The URI of all subsequent segments will replace clip.mpd with seg_<index>.m4v
 		// These files will need to be appended to our existing clip.mp4 in disk
-		const uri = mpdUri.replace(mpdName, "seg_" + i + ".m4v");
+		const uri = getSegmentURI(i, mpdUri, rhombusMPDInfo, mpdName);
 		await saveClip(outputPath, uri);
 		debugLog("Saved segment: " + uri)
 	}

--- a/CopyFootageToLocalStorage/package.json
+++ b/CopyFootageToLocalStorage/package.json
@@ -24,6 +24,7 @@
     "axios": "^0.21.1",
     "csv-writer": "^1.6.0",
     "dotenv": "^10.0.0",
+    "fast-xml-parser": "^4.0.0-beta.8",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"
   },

--- a/ExtendedAIModule/README.md
+++ b/ExtendedAIModule/README.md
@@ -21,11 +21,11 @@ NOTE: If you have already generated the Typescript client and have a RhombusType
 4. Run `npm install` in the ExtendedAIModule directory
 5. Create a `.env` file in the ExtendedAIModule source directory using the following structure (without the angle brackets)
 
-    API_KEY=<YOUR API KEY>
+    API_KEY=`<YOUR API KEY>`
 
-    CAM_UUID=<YOUR CAMERA UUID>
+    CAM_UUID=`<YOUR CAMERA UUID>`
 
-    CONNECTION_TYPE=<WAN OR LAN> 
+    CONNECTION_TYPE=`<WAN OR LAN>`
 
 NOTE: CONNECTION_TYPE parameter is optional, but it will specify whether to use a WAN or LAN connection from the camera to download the VODs. It is by default LAN and unless the NodeJS server is running on a separate wifi from the camera, which would be very unlikely...
 6. Run the example using `npm run start`

--- a/ExtendedAIModule/package.json
+++ b/ExtendedAIModule/package.json
@@ -31,6 +31,7 @@
     "@types/isomorphic-fetch": "^0.0.35",
     "axios": "^0.21.1",
     "dotenv": "^10.0.0",
+    "fast-xml-parser": "^4.0.0",
     "ffmpeg-static": "^4.3.0",
     "image-size": "^1.0.0",
     "isomorphic-fetch": "^3.0.0",

--- a/ExtendedAIModule/src/services/vod_fetcher.ts
+++ b/ExtendedAIModule/src/services/vod_fetcher.ts
@@ -46,6 +46,12 @@ const axios = require('axios').default;
 import * as fs from "fs";
 
 /*
+  * 
+  * @import XML parser so that we can parse the MPD document
+  * */
+import { XMLParser } from "fast-xml-parser";
+
+/*
   *
   * @export
   * @interface Result after calling `FetchVOD`
@@ -107,6 +113,68 @@ export const saveClip = async (path: string, uri: string, write: boolean = false
 }
 
 /*
+  * 
+  * @export
+  * @interface RhombusMPDInfo
+  *
+  * */
+export interface RhombusMPDInfo {
+	/*
+	  * @type {string} The pattern containing "$Number$" which can be replaced with an index that is incremented for each segment.
+	  * @memberof RhombusMPDInfo
+	  * */
+	segPattern: string;
+
+	/*
+	  * @type {string} The string which is appended to the end of the mpd URI to get the start mp4 file.
+	  * @memberof RhombusMPDInfo
+	  * */
+	segInitStr: string;
+
+	/*
+	  * @type {number} The starting index which will be incremented for each segment.
+	  * @memberof RhombusMPDInfo
+	  * */
+	startIndex: number;
+}
+
+/*
+  *
+  * @export 
+  * @method Parse relevant information from a raw MPD XML string.
+  *
+  * @param {string} [mpdDocRaw] the raw XML string that is retrieved from downloading the mpd document from a Rhombus URI.
+  * @return {RhombusMPDInfo} the info relevant to downloading from MPD stream.
+  * */
+export const parseRhombusMPD = (mpdDocRaw: string): RhombusMPDInfo => {
+	const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "" });
+	const mpdDoc = parser.parse(mpdDocRaw);
+
+	const segmentTemplate = mpdDoc.MPD.Period.AdaptationSet.SegmentTemplate;
+
+	return {
+		segPattern: segmentTemplate.media,
+		segInitStr: segmentTemplate.initialization,
+		startIndex: parseInt(segmentTemplate.startNumber),
+	};
+}
+
+/*
+  *
+  * @export 
+  * @method Save an m4v or mp4 url to the specified output file
+  *
+  * @param {number} [index] the segment index starting at 0.
+  * @param {string} [mpdUri] the MPD URI with the correct start and end times. This should have a file.mpd or clip.mpd ending.
+  * @param {RhombusMPDInfo} [rhombusInfo] the MPD info parsed using `parseRhombusMPD(string)`.
+  * @param {string} [mpdName] either "file.mpd" or "clip.mpd", depending on if you are using WAN or LAN.
+  * */
+export const getSegmentURI = (index: number, mpdUri: string, rhombusInfo: RhombusMPDInfo, mpdName: string): string => {
+	const replacement = rhombusInfo.segPattern.replace("$Number$", (index + rhombusInfo.startIndex).toString());
+	return mpdUri.replace(mpdName, replacement);
+}
+
+/*
   *
   * @export 
   * @method Download a vod to disk. It will be saved in res/<current time in seconds>
@@ -136,12 +204,16 @@ export const FetchVOD = async (config: Configuration, federatedToken: string, ur
 	// The federated token is set as a cookie. Without this we would be unable to download the files from Rhombus
 	axios.defaults.headers.common['Cookie'] = 'RSESSIONID=RFT:' + federatedToken;
 
+	// Get the Rhombus MPD Doc info.
+	const mpdDocRaw = await axios.get(fullURI, { responseType: "json" });
+	const rhombusInfo = parseRhombusMPD(mpdDocRaw.data);
+
 	// The directory where we will place our clip is "<PROJECT_ROOT>/res/<startTime>"
 	const dir = "./res/" + startTime + "/";
 
 	// If the directory does not already exist, then we need to create it
 	if (!fs.existsSync(dir))
-		fs.mkdirSync(dir);
+		fs.mkdirSync(dir, { recursive: true });
 
 	// The path of the clip is dir/clip.mp4 regardless of timestamp. The file is always called clip.mp4
 	const path = dir + "clip.mp4";
@@ -152,13 +224,13 @@ export const FetchVOD = async (config: Configuration, federatedToken: string, ur
 	// Because our URI is an mpd, we need to get each of the segments. The seg_init.mp4 is the first of these. 
 	// Just replace clip.mpd at the end of the URL with seg_init.mp4 
 	// This also needs to be written since this is the first of our segments
-	await saveClip(path, fullURI.replace(mpdName, "seg_init.mp4"), true);
+	await saveClip(path, fullURI.replace(mpdName, rhombusInfo.segInitStr), true);
 
 	// Each of the segments is 2 seconds long, so the number of segments is duration/2
 	for (let i = 0; i < duration / 2; i++) {
 		// The URI of all subsequent segments will replace clip.mpd with seg_<index>.m4v
 		// These files will need to be appended to our existing clip.mp4 in disk
-		await saveClip(path, fullURI.replace(mpdName, "seg_" + i + ".m4v"));
+		await saveClip(path, getSegmentURI(i, fullURI, rhombusInfo, mpdName));
 	}
 
 	// Return our data

--- a/ListOfUsersExample/README.md
+++ b/ListOfUsersExample/README.md
@@ -21,11 +21,11 @@ NOTE: If you have already generated the Typescript client and have a RhombusType
 4. Run `npm install` in the ListOfUsersExample directory
 5. Create a `.env` file in the ListOfUsersExample source directory using the following structure (without the angle brackets)
 
-    API_KEY=<YOUR API KEY>
+    API_KEY=`<YOUR API KEY>`
 
-    OUTPUT_PATH=<PATH TO OUTPUT CSV>
+    OUTPUT_PATH=`<PATH TO OUTPUT CSV>`
 
-    NAMES=<COMMA SEPARATED NAMES IN QUOTES> 
+    NAMES=`<COMMA SEPARATED NAMES IN QUOTES>`
 
 The `NAMES` parameter is optional. It will filter the users and only output users with the specified names
 

--- a/VideoStitcher/README.md
+++ b/VideoStitcher/README.md
@@ -20,9 +20,9 @@ NOTE: If you have already generated the Typescript client and have a RhombusType
 4. Run `npm install` in the VideoStitcher directory
 5. Create a `.env` file in the VideoStitcher source directory using the following structure (without the angle brackets)
 
-    API_KEY=<YOUR API KEY>
+    API_KEY=`<YOUR API KEY>`
 
-    CONNECTION_TYPE=<WAN OR LAN> 
+    CONNECTION_TYPE=`<WAN or LAN>`
 
 NOTE: CONNECTION_TYPE parameter is optional, but it will specify whether to use a WAN or LAN connection from the camera to download the VODs. It is by default LAN and unless the NodeJS server is running on a separate wifi from the camera, which would be very unlikely...
 

--- a/VideoStitcher/package.json
+++ b/VideoStitcher/package.json
@@ -32,6 +32,7 @@
     "@types/prompts": "^2.0.13",
     "axios": "^0.21.1",
     "dotenv": "^10.0.0",
+    "fast-xml-parser": "^4.0.0",
     "ffmpeg-static": "^4.3.0",
     "image-size": "^1.0.0",
     "isomorphic-fetch": "^3.0.0",


### PR DESCRIPTION
I also fixed a few README.md issues that I noticed. 

One thing to note, there is essentially no error checking for all of the MPD parsings (I am just assuming all of the tags and attributes are there and haven't changed. If something is missing the user will simply see a JS error that says like, "Cannot get <attribute> of undefined"). My reasoning for this is that because these are examples, we want developers to be able to copy a working and simple implementation to use in their own codebase, not a 500 line fully-featured implementation with all of the bells and whistles. I can totally add the error checking, however, I think it would be unnecessarily verbose and more difficult for developers to understand with little benefit.